### PR TITLE
fix language id & configuration file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "contributes": {
 		"languages": [
 			{
-				"id": "source.css.styled",
+				"id": "source.jsx.styled",
 				"aliases": [
 					"CSS (jsx styled)"
 				],
@@ -26,8 +26,8 @@
 		],
 		"grammars": [
 			{
-				"language": "source.css.styled",
-				"scopeName": "source.css.styled",
+				"language": "source.jsx.styled",
+				"scopeName": "source.jsx.styled",
 				"path": "./syntaxes/css.json"
 			},
 			{

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "contributes": {
 		"languages": [
 			{
-				"id": "source.jsx.styled",
+				"id": "source.css.styled",
 				"aliases": [
 					"CSS (jsx styled)"
 				],
-				"configuration": "./language.configuration.json"
+				"configuration": "./language-configuration.json"
 			}
 		],
 		"grammars": [

--- a/syntaxes/css.json
+++ b/syntaxes/css.json
@@ -1,6 +1,6 @@
 {
   "name": "Styled CSS",
-  "scopeName": "source.css.styled",
+  "scopeName": "source.jsx.styled",
   "foldingStartMarker": "(/\\*|{|\\()",
   "foldingEndMarker": "(\\*/|\\}|\\))",
   "fileTypes": [
@@ -238,7 +238,7 @@
             {"include": "#css-values"}
           ]
         },
-        { 
+        {
           "contentName": "meta.property-values.css",
           "begin": "(?i)(?<=^|[\\W])\\s*+((-(webkit|moz|o|ms)-)?(animation(-(timing-function|play-state|name|iteration-count|fill-mode|duration|direction|delay))?))\\s*+(:)",
           "end": "(;)|(?=[`})\\]])",

--- a/syntaxes/jsx-styled.json
+++ b/syntaxes/jsx-styled.json
@@ -3,7 +3,7 @@
 	"injectionSelector": "L:source -comment",
 	"patterns": [
     {
-      "contentName": "source.css.styled",
+      "contentName": "source.jsx.styled",
       "begin": "\\s*+((?<=<style jsx>{)|(?<=<style jsx global>{))\\s*(`)",
       "beginCaptures": {
         "1": { "name": "entity.name.tag.js" },
@@ -14,7 +14,7 @@
         "1": { "name": "punctuation.definition.quasi.end.js" }
       },
       "patterns": [
-        { "include": "source.css.styled" }
+        { "include": "source.jsx.styled" }
       ]
     }
 	],


### PR DESCRIPTION
- incorrect language id causes vscode to give error 
```
Unknown language in `contributes.grammars.language`. Provided value: source.css.styled
```

- I'm actually getting the correct file name `language.configuration.json` in vscode's extensions folder, but I'm seeing different things here so making the change based on the current repo's value