### PR TITLE
Add support for 'css' template literal tag

### DIFF
--- a/syntaxes/jsx-styled.json
+++ b/syntaxes/jsx-styled.json
@@ -9,7 +9,7 @@
   "patterns": [
     {
       "contentName": "source.jsx.styled",
-      "begin": "\\s*+((?<=<style jsx>{)|(?<=<style jsx global>{))\\s*(`)",
+      "begin": "\\s*+((?<=<style jsx>{)|(?<=<style jsx global>{)|css)\\s*(`)",
       "beginCaptures": {
         "1": {
           "name": "entity.name.tag.js"


### PR DESCRIPTION
Support the css tag feature:
https://github.com/zeit/styled-jsx#keeping-css-in-separate-files

p.s many thanks for making this extension 😍