### PR TITLE
Add support for 'resolve' and 'global' tags

### DIFF
--- a/syntaxes/jsx-styled.json
+++ b/syntaxes/jsx-styled.json
@@ -9,7 +9,30 @@
   "patterns": [
     {
       "contentName": "source.jsx.styled",
-      "begin": "\\s*+((?<=<style jsx>{)|(?<=<style jsx global>{)|(?<=<style global jsx>{)|css)\\s*(`)",
+      "begin": "\\s*+((?<=<style jsx>{)|(?<=<style jsx global>{)|(?<=<style global jsx>{)|css|global|resolve)\\s*(`)",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.js"
+        },
+        "2": {
+          "name": "punctuation.definition.quasi.begin.js"
+        }
+      },
+      "end": "\\s*(?<=[^\\\\]\\\\\\\\|[^\\\\]|^\\\\\\\\|^)((`))",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.quasi.end.js"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.jsx.styled"
+        }
+      ]
+    },
+    {
+      "contentName": "source.jsx.styled",
+      "begin": "([_$[:alpha:]][_$[:alnum:]]*\\.(?:resolve|global))\\s*(`)",
       "beginCaptures": {
         "1": {
           "name": "entity.name.tag.js"


### PR DESCRIPTION
Support highlighting for `3.0` tags
https://github.com/zeit/styled-jsx#external-css-and-styles-outside-of-the-component