### PR TITLE
Enable highlighting for css.resolve/css.global

### DIFF
--- a/syntaxes/jsx-styled.json
+++ b/syntaxes/jsx-styled.json
@@ -80,7 +80,7 @@
     },
 		{
 			"contentName": "source.css.scss",
-			"begin": "(?:(?:(\\.)(resolve|global))|(\\bcss))(`)",
+			"begin": "(?:(?:(\\bcss\\.)(resolve|global))|(\\bcss))(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "punctuation.accessor.js"


### PR DESCRIPTION
Prior to this commit, css on it's own would correctly syntax highlight everything between it's backticks, but not `css.resolve` or `css.global`. I think this was due to a TextMate regex quirk -- `anything.resolve` *should* have matched, but TextMate regexes seem to implicitly start at work boundaries.

The fix is to add `\\bcss` before checking for the `.resolve` or `.global` bits. Sure, this is a bit more restrictive (you can't have `anything.resolve` anymore), but css is already hard coded for the css`` case.

Fixes #20.