### PR TITLE
fix: minor style tag highlight on last pattern

### DIFF
--- a/syntaxes/jsx-styled.json
+++ b/syntaxes/jsx-styled.json
@@ -3,7 +3,7 @@
   "injectionSelector": "L:source -comment -string",
   "patterns": [
     {
-      "begin": "\\s*(<)(style) (jsx)(>)|\\s*(<)(style) (global jsx)(>)|\\s*(<)(style) (jsx global)(>)",
+      "begin": "\\s*(<)(style) (jsx|global jsx|jsx global)(>)",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.tag.begin.ts.tsx"


### PR DESCRIPTION
On version 1.5.0, case `<style global jsx>` had broken tag highlights. On version 2.0.0, case `<style jsx global>` has broken tag highlights as a result of it being switched as the last OR case. Not entirely sure what the cause of this might be, but there is no need to overcomplicate the expression cases and make `jsx`, `jsx global`, and `global jsx` as a single capture group.

Current version (2.0.0):
![image](https://user-images.githubusercontent.com/1130103/95103640-0e694680-075f-11eb-94b8-8fb3dc92b61d.png)

Proposed change:
![image](https://user-images.githubusercontent.com/1130103/95103706-250f9d80-075f-11eb-9fa2-1a210691f212.png)
